### PR TITLE
Read route parameter frrom path instead of query

### DIFF
--- a/app/controllers/author.controller.ts
+++ b/app/controllers/author.controller.ts
@@ -13,7 +13,7 @@ router.get('/', async (ctx: Context) => {
 
 router.get('/:id', async (ctx: Context) => {
   try {
-    const author = await DI.authorRepository.findOne(ctx.query.id, ['books']);
+    const author = await DI.authorRepository.findOne(ctx.params.id, ['books']);
 
     if (!author) {
       return ctx.throw(404, { message: 'Author not found' });

--- a/app/controllers/book.controller.ts
+++ b/app/controllers/book.controller.ts
@@ -12,7 +12,7 @@ router.get('/', async (ctx: Context) => {
 
 router.get('/:id', async (ctx: Context) => {
   try {
-    const book = await DI.bookRepository.findOne(ctx.path.id, ['author']);
+    const book = await DI.bookRepository.findOne(ctx.params.id, ['author']);
 
     if (!book) {
       return ctx.throw(404, { message: 'Book not found' });
@@ -43,7 +43,7 @@ router.post('/', async (ctx: Context) => {
 
 router.put('/:id', async (ctx: Context) => {
   try {
-    const book = await DI.bookRepository.findOne(ctx.path.id);
+    const book = await DI.bookRepository.findOne(ctx.params.id);
 
     if (!book) {
       return ctx.throw(404, { message: 'Book not found' });

--- a/app/controllers/book.controller.ts
+++ b/app/controllers/book.controller.ts
@@ -12,7 +12,7 @@ router.get('/', async (ctx: Context) => {
 
 router.get('/:id', async (ctx: Context) => {
   try {
-    const book = await DI.bookRepository.findOne(ctx.query.id, ['author']);
+    const book = await DI.bookRepository.findOne(ctx.path.id, ['author']);
 
     if (!book) {
       return ctx.throw(404, { message: 'Book not found' });
@@ -43,7 +43,7 @@ router.post('/', async (ctx: Context) => {
 
 router.put('/:id', async (ctx: Context) => {
   try {
-    const book = await DI.bookRepository.findOne(ctx.query.id);
+    const book = await DI.bookRepository.findOne(ctx.path.id);
 
     if (!book) {
       return ctx.throw(404, { message: 'Book not found' });


### PR DESCRIPTION
At this moment id is being read from url query, instead of path which is described in docs:

https://github.com/mikro-orm/koa-ts-example-app/blob/145c32978a5cc276266fd98985d2cb5e08ef8cdd/README.md?plain=1#L8-L22

Changed behaviour:

```console
# Current
curl -X GET "http://localhost:3000/author/1?id=1"
# Fixed
curl -X GET "http://localhost:3000/author/1"
```